### PR TITLE
Update meta.yaml

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,15 +11,11 @@ source:
   sha256: 0ab402f73fc8cc41f2a5523436ae53dec6ff612597d9168ed80cfa1574d27fe0
 
 build:
-  number: 0
+  number: 1
   noarch: python
   entry_points:
     - py7zr = py7zr.__main__:main
   script: 
-    # The tarball shouldn't have egg-info--this one has paths in SOURCES.txt
-    # that break the build on windows.
-    - rm -rf py7zr.egg-info  # [not win]
-    - del /s /q py7zr.egg-info  # [win]
     - {{ PYTHON }} -m pip install . -vv
 
 requirements:


### PR DESCRIPTION
No reason to remove *.egg-info from pure python library source

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

- *.egg-info is standard files in packaging with setuptools. There is no reason to remove it. A comment expressing breakage is also wrong.