### PR TITLE
Update run requirements to match setup.cfg of v0.17.4

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
   sha256: 1df67edaa8dd1613fc5a7de3354322e7bc75d989d6069924ce2d08bb7fabdd19
 
 build:
-  number: 0
+  number: 1
   noarch: python
   entry_points:
     - py7zr = py7zr.__main__:main
@@ -25,15 +25,14 @@ requirements:
     - setuptools >=45.0
     - setuptools-scm >=6.0.1
   run:
-    - bcj-cffi >=0.5.1,<0.6.0
     - brotli-python >=1.0.9
     - brotlicffi >=1.0.9.2
     - importlib_metadata
     - multivolumefile >=0.2.3
     - pycryptodomex >=3.6.6
-    - pyppmd >=0.15.0
+    - pyppmd >=0.17.0
     - python >=3.6
-    - pyzstd >=0.14.4,<0.15.0
+    - pyzstd >=0.14.4
     - texttable
     - pybcpy
     - pybcj


### PR DESCRIPTION
Update run requirements to match [setup.cfg of v0.17.4](https://github.com/miurahr/py7zr/blob/v0.17.4/setup.cfg#L39-L48)

I noticed that `py7zr` is currently not installable from conda-forge with python 3.10, e.g. the command below fails:
```
conda create -n test --dry-run -c conda-forge py7zr python=3.10
```
This is due to the fact that there is no py310-build of `bcj-cffi`. But apparently `bcj-cffi` is not used anymore, so the requirement should be dropped in the recipe.

I also updated the other requirements to match those in setup.cfg.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
